### PR TITLE
Bibliography edits

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -2,7 +2,7 @@
   title = {Networking the forest infrastructure towards near real-time monitoring – A white paper},
   volume = {872},
   ISSN = {0048-9697},
-  url = {\url{https://www.sciencedirect.com/science/article/abs/pii/S0048969723007830}},
+  url = {https://www.sciencedirect.com/science/article/abs/pii/S0048969723007830},
   DOI = {10.1016/j.scitotenv.2023.162167},
   journal = {Science of The Total Environment},
   publisher = {Elsevier BV},
@@ -14,10 +14,10 @@
 }
 
 @article{Bogena2022,
-  title = {COSMOS-Europe: a European network of cosmic-ray neutron soil moisture sensors},
+  title = {{COSMOS-Europe: a European network of cosmic-ray neutron soil moisture sensors}},
   volume = {14},
   ISSN = {1866-3516},
-  url = {\url{https://essd.copernicus.org/articles/14/1125/2022}},
+  url = {https://essd.copernicus.org/articles/14/1125/2022},
   DOI = {10.5194/essd-14-1125-2022},
   number = {3},
   journal = {Earth System Science Data},
@@ -29,10 +29,10 @@
 }
 
 @article{Dorigo2021,
-  title = {The International Soil Moisture Network: serving  Earth system science for over a decade},
+  title = {{The International Soil Moisture Network: serving Earth system science for over a decade}},
   volume = {25},
   ISSN = {1607-7938},
-  url = {\url{https://hess.copernicus.org/articles/25/5749/2021}},
+  url = {https://hess.copernicus.org/articles/25/5749/2021},
   DOI = {10.5194/hess-25-5749-2021},
   number = {11},
   journal = {Hydrology and Earth System Sciences},
@@ -44,10 +44,10 @@
 }
 
 @article{Zweifel2021,
-  title = {TreeNet–The Biological Drought and Growth Indicator Network},
+  title = {{TreeNet–The Biological Drought and Growth Indicator Network}},
   volume = {4},
   ISSN = {2624-893X},
-  url = {\url{https://www.frontiersin.org/articles/10.3389/ffgc.2021.776905/full}},
+  url = {https://www.frontiersin.org/articles/10.3389/ffgc.2021.776905/full},
   DOI = {10.3389/ffgc.2021.776905},
   journal = {Frontiers in Forests and Global Change},
   publisher = {Frontiers Media SA},
@@ -61,7 +61,7 @@
   title = {A Surface Ocean CO2 Reference Network,  SOCONET and Associated Marine Boundary Layer CO2 Measurements},
   volume = {6},
   ISSN = {2296-7745},
-  url = {\url{https://www.frontiersin.org/articles/10.3389/fmars.2019.00400/full}},
+  url = {https://www.frontiersin.org/articles/10.3389/fmars.2019.00400/full},
   DOI = {10.3389/fmars.2019.00400},
   journal = {Frontiers in Marine Science},
   publisher = {Frontiers Media SA},
@@ -71,10 +71,10 @@
 }
 
 @article{AlYaari2018,
-  title = {The AQUI Soil Moisture Network for Satellite Microwave Remote Sensing Validation in South-Western France},
+  title = {{The AQUI Soil Moisture Network for Satellite Microwave Remote Sensing Validation in South-Western France}},
   volume = {10},
   ISSN = {2072-4292},
-  url = {\url{https://www.mdpi.com/2072-4292/10/11/1839}},
+  url = {https://www.mdpi.com/2072-4292/10/11/1839},
   DOI = {10.3390/rs10111839},
   number = {11},
   journal = {Remote Sensing},
@@ -86,10 +86,10 @@
 }
 
 @article{Shusterman2016,
-  title = {The BErkeley Atmospheric CO&amp;lt;sub&amp;gt;2&amp;lt;/sub&amp;gt; Observation Network: initial evaluation},
+  title = {{The BErkeley Atmospheric CO$_\mathsf{2}$ Observation Network: initial evaluation}},
   volume = {16},
   ISSN = {1680-7324},
-  url = {\url{https://acp.copernicus.org/articles/16/13449/2016}},
+  url = {https://acp.copernicus.org/articles/16/13449/2016},
   DOI = {10.5194/acp-16-13449-2016},
   number = {21},
   journal = {Atmospheric Chemistry and Physics},
@@ -108,12 +108,12 @@
     year = {2021},
     number = {2},
     pages = {1111--1126},
-    url = {\url{https://amt.copernicus.org/articles/14/1111/2021}},
+    url = {https://amt.copernicus.org/articles/14/1111/2021},
     doi = {10.5194/amt-14-1111-2021}
 }
 
 @article{Bares2019,
-  title = {The Utah urban carbon dioxide (UUCON) and Uintah Basin greenhouse gas networks: instrumentation,  data,  and measurement uncertainty},
+  title = {{The Utah urban carbon dioxide (UUCON) and Uintah Basin greenhouse gas networks: instrumentation,  data,  and measurement uncertainty}},
   volume = {11},
   ISSN = {1866-3516},
   url = {http://dx.doi.org/10.5194/essd-11-1291-2019},
@@ -128,25 +128,25 @@
 }
 @article{Aigner2023,
     doi = {10.21105/joss.05131},
-    url = {\url{https://joss.theoj.org/papers/10.21105/joss.05131}},
+    url = {https://joss.theoj.org/papers/10.21105/joss.05131},
     year = {2023},
     publisher = {The Open Journal},
     volume = {8},
     number = {84},
     pages = {5131},
     author = {Aigner, Patrick and Makowski, Moritz and Luther, Andreas and Dietrich, Florian and Chen, Jia},
-    title = {Pyra: Automated EM27/SUN Greenhouse Gas Measurement Software},
+    title = {{Pyra: Automated EM27/SUN Greenhouse Gas Measurement Software}},
     journal = {Journal of Open Source Software}
 }
 
 @article{Caubel2019,
-  title = {A Distributed Network of 100 Black Carbon Sensors for 100 Days of Air Quality Monitoring in West Oakland,  California},
+  title = {{A Distributed Network of 100 Black Carbon Sensors for 100 Days of Air Quality Monitoring in West Oakland, California}},
   volume = {53},
   ISSN = {1520-5851},
   url = {http://dx.doi.org/10.1021/acs.est.9b00282},
   DOI = {10.1021/acs.est.9b00282},
   number = {13},
-  journal = {Environmental Science &amp; Technology},
+  journal = {Environmental Science \& Technology},
   publisher = {American Chemical Society (ACS)},
   author = {Caubel,  Julien J. and Cados,  Troy E. and Preble,  Chelsea V. and Kirchstetter,  Thomas W.},
   year = {2019},
@@ -170,7 +170,7 @@
 }
 
 @article{Wenzel2021,
-  title = {Stand-alone low-cost sensor network in the inner city of Munich for modeling urban air pollutants},
+  title = {{Stand-alone low-cost sensor network in the inner city of Munich for modeling urban air pollutants}},
   url = {http://dx.doi.org/10.5194/egusphere-egu21-15182},
   DOI = {10.5194/egusphere-egu21-15182},
   publisher = {Copernicus GmbH},
@@ -196,7 +196,7 @@
 @software{frostpythonclient,
   author = {Vogl, Jonathan},
   title = {Python Client Library for FROST},
-  howpublished = {\url{https://github.com/FraunhoferIOSB/FROST-Python-Client}},
+  url = {https://github.com/FraunhoferIOSB/FROST-Python-Client},
   version = {1.1.45},
   date = {2023-11-08}
 }
@@ -204,14 +204,14 @@
 @software{thingsboardclientsdk,
   author = {{ThingsBoard}},
   title = {ThingsBoard client Python SDK},
-  url = {\url{https://github.com/thingsboard/thingsboard-python-client-sdk}},
+  url = {https://github.com/thingsboard/thingsboard-python-client-sdk},
   version={1.10.10},
   date = {2024-11-05}
 }
 
 @software{hermes,
   author = {{TUM ESM} and Aigner, Patrick and Böhm, Felix and Frölich, Lars and Makowski, Moritz and Schmitt, Adrian and Chen, Jia},
-  title = {Hermes, Professorship of Environmental Sensing and Modeling, Technical University of Munich},
+  title = {{Hermes, Professorship of Environmental Sensing and Modeling, Technical University of Munich}},
   url = {https://github.com/tum-esm/hermes},
   version = {1.0.1},
   date = {2024-10-14}
@@ -219,7 +219,7 @@
 
 @incollection{IPCC_2021_WGI_SPM,
    title = {Summary for Policymakers},
-   booktitle = {Climate Change 2021: The Physical Science Basis. Contribution of Working Group I to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change},
+   booktitle = {{Climate Change 2021: The Physical Science Basis. Contribution of Working Group I to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change}},
    publisher = {Cambridge University Press},
    address = {Cambridge, United Kingdom and New York, NY, USA},
    url = {https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_SPM.pdf},
@@ -233,7 +233,7 @@
 
 @incollection{IPCC_2022_WGII_SPM,
    title = {Summary for Policymakers},
-   booktitle = {Climate Change 2021: Impacts, Adaptation and Vulnerability. Contribution of Working Group II to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change},
+   booktitle = {{Climate Change 2021: Impacts, Adaptation and Vulnerability. Contribution of Working Group II to the Sixth Assessment Report of the Intergovernmental Panel on Climate Change}},
    publisher = {Cambridge University Press},
    address = {Cambridge, United Kingdom and New York, NY, USA},
    url = {https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_SummaryForPolicymakers.pdf},
@@ -246,13 +246,13 @@
 }
 
 @article{Bart2014,
-  title = {High Density Ozone Monitoring Using Gas Sensitive Semi-Conductor Sensors in the Lower Fraser Valley,  British Columbia},
+  title = {{High Density Ozone Monitoring Using Gas Sensitive Semi-Conductor Sensors in the Lower Fraser Valley, British Columbia}},
   volume = {48},
   ISSN = {1520-5851},
   url = {http://dx.doi.org/10.1021/es404610t},
   DOI = {10.1021/es404610t},
   number = {7},
-  journal = {Environmental Science &amp; Technology},
+  journal = {Environmental Science \& Technology},
   publisher = {American Chemical Society (ACS)},
   author = {Bart,  Mark and Williams,  David E and Ainslie,  Bruce and McKendry,  Ian and Salmond,  Jennifer and Grange,  Stuart K. and Alavi-Shoshtari,  Maryam and Steyn,  Douw and Henshaw,  Geoff S.},
   year = {2014},
@@ -282,7 +282,7 @@
 
 @software{acropolis-edge,
   author = {{TUM ESM} and Aigner, Patrick and Böhm, Felix and Frölich, Lars and Makowski, Moritz and Schmitt, Adrian and Chen, Jia}, 
-  title = {ACROPOLIS-edge, Professorship of Environmental Sensing and Modeling, Technical University of Munich},
+  title = {{ACROPOLIS-edge, Professorship of Environmental Sensing and Modeling, Technical University of Munich}},
   url = {https://github.com/tum-esm/ACROPOLIS-edge},
   version = {0.0.95},
   date = {2025-04-04}
@@ -368,9 +368,9 @@
 
 @online{paul,
   author = {{European Commission}},
-  title = {Horizon 2020 - Pilot Application in Urban Landscapes},
-  url = {\url{https://cordis.europa.eu/project/id/101037319}},
-  doi = {10.2777/12345},
+  title = {{Pilot Application in Urban Landscapes - Towards integrated city observatories for greenhouse gases}},
+  url = {https://cordis.europa.eu/project/id/101037319},
+  doi = {10.3030/101037319},
   year = {2021},
   urldate = {2024-11-15}
 }
@@ -384,7 +384,7 @@
 
 @inproceedings{midcost,
 	author = {Aigner, Patrick and Kühbacher, Daniel and Wenzel, Adrian and  Schmitt, Adrian and Böhm, Felix and Makowski, Moritz and Kürzinger, Klaus and Laurent, Olivier and Rubli, Pascal and Grange, Stuart and Emmenegger, Lukas and Chen, Jia},
-	title = {Advancing Urban Greenhouse Gas Monitoring: Development and Evaluation of a High-Density CO2 Sensor Network in Munich},
+	title = {{Advancing Urban Greenhouse Gas Monitoring: Development and Evaluation of a High-Density CO$_\mathsf{2}$ Sensor Network in Munich}},
 	booktitle = {ICOS Science Conference 2024},
 	year = {2024},
   url = {https://www.icos-cp.eu/news-and-events/science-conference/icos2024sc/all-abstracts},
@@ -465,7 +465,7 @@ year = {2025}
 }
 
 @article{Wenzel2025,
-  title = {Towards high-resolution air pollutants sensing through dense low-cost sensor networks &amp;#8211; a case study in Munich},
+  title = {{Towards high-resolution air pollutants sensing through dense low-cost sensor networks – a case study in Munich}},
   url = {http://dx.doi.org/10.5194/egusphere-egu25-16784},
   DOI = {10.5194/egusphere-egu25-16784},
   publisher = {Copernicus GmbH},


### PR DESCRIPTION
Regarding [JOSS review #8862](https://github.com/openjournals/joss-reviews/issues/8862), I found some issues with the paper bibliography. They are mostly capitalization issues, but there are a few so it was best to make a PR. Please review the changes carefully (as detailed below).

#### Capitalization and render issues

- [x] Aigner (2024): (current) munich and CO2 &rarr; (expect) Munich and CO₂
- [x] Aigner (2023): title words capitalization
- [x] Al-Yaari:  South-Western France
- [x] Bares:  Utah and Uintah Basin
- [x] Bart: Lower Fraser Valley, British Columbia
- [x] Bart, Caubel: (journal) Environmental Science \& Technology
- [x] Bogena: Europe and European
- [x] Caubel: West Oakland, California
- [x] Dorigo: International Soil Moisture Network and Earth
- [x] IPCC 2021 and 2022: booktitle capitalization, e.g., i &rarr; I
- [x] Shusterman: CO&amp;lt;sub&amp;gt;2&amp;lt;/sub&amp;gt; &rarr; CO₂
- [x] TUM ESM (2x): Technical University of Munich
- [x] Wenzel (2021): Munich
- [x] Wenzel (2025): the title did not render (fixed); `&amp;#8211;` &rarr; `–`
- [x] Zweifel (2021): title words capitalization

All of these are fixed.

#### Reference issue with European Commission (2021)

The given [DOI 10.2777/12345](https://doi.org/10.2777/12345) points to a document by a different name, _"Facilitating market development for sections in industrial halls and low-rise buildings (Sechalo)."_

Following the URL of the bib entry (https://cordis.europa.eu/project/id/101037319) reveals the correct DOI; should be 10.3030/101037319. Also, the full title is _"Pilot Application in Urban Landscapes - Towards integrated city observatories for greenhouse gases"_.

This is fixed.

#### Recommendations

Finally, there were some repeating patterns in the bib. I would like to offer the following general recommendations for future publications.

* To preserve capitalization use double brackets around the attribute value, e.g., `title = {{…}}`   
   or,  use `{…}` around specific character sequences, e.g., `title = {…{M}unich…}`.
* The pattern `&amp;` (which is used in HTML) becomes `\&` in a biblatex file
* A url value does not need `url{ }`, i.e., replace `url={\url{https://…}}` with `url={https://…}`   
  (in `howpublished` adding `\url{}` is fine).

